### PR TITLE
Write all files into log dir

### DIFF
--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -7,10 +7,10 @@ import time
 from . import condor
 from . import slurm
 from .remote import INFILE_FMT, OUTFILE_FMT
-from .util import random_string
+from .util import random_string, local_filename
 import cloudpickle
 
-LOGFILE_FMT = 'cfut.log.%s.txt'
+LOGFILE_FMT = local_filename('cfut.log.%s.txt')
 
 class RemoteException(Exception):
     def __init__(self, error):

--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -65,6 +65,7 @@ class ClusterExecutor(futures.Executor):
     """An abstract base class for executors that run jobs on clusters.
     """
     def __init__(self, debug=False, keep_logs=False):
+        os.makedirs(local_filename(), exist_ok=True)
         self.debug = debug
 
         self.jobs = {}

--- a/cfut/condor.py
+++ b/cfut/condor.py
@@ -5,10 +5,11 @@ import re
 import os
 import threading
 import time
+from .util import local_filename
 
-LOG_FILE = "condorpy.log"
-OUTFILE_FMT = "condorpy.stdout.%s.log"
-ERRFILE_FMT = "condorpy.stderr.%s.log"
+LOG_FILE = local_filename("condorpy.log")
+OUTFILE_FMT = local_filename("condorpy.stdout.%s.log")
+ERRFILE_FMT = local_filename("condorpy.stderr.%s.log")
 
 def call(command, stdin=None):
     """Invokes a shell command as a subprocess, optionally with some
@@ -79,7 +80,7 @@ def submit_script(script, **kwargs):
     with the name of the temporary script file executed. (This should
     probably be removed once the job completes.)
     """
-    filename = 'condorpy.jobscript.%s'
+    filename = local_filename('condorpy.jobscript.%s')
     with open(filename, 'w') as f:
         f.write(script)
     os.chmod(filename, 0o755)

--- a/cfut/condor.py
+++ b/cfut/condor.py
@@ -159,9 +159,9 @@ class WaitThread(threading.Thread):
 if __name__ == '__main__':
     jid, jfn = submit_script("#!/bin/sh\necho hey there")
     try:
-        print "running job %i" % jid
+        print("running job %i" % jid)
         stdout, stderr = getoutput(jid)
-        print "job done"
-        print stdout
+        print("job done")
+        print(stdout)
     finally:
         os.unlink(jfn)

--- a/cfut/remote.py
+++ b/cfut/remote.py
@@ -3,9 +3,10 @@ import cloudpickle
 import sys
 import os
 import traceback
+from .util import local_filename
 
-INFILE_FMT = 'cfut.in.%s.pickle'
-OUTFILE_FMT = 'cfut.out.%s.pickle'
+INFILE_FMT = local_filename('cfut.in.%s.pickle')
+OUTFILE_FMT = local_filename('cfut.out.%s.pickle')
 
 def format_remote_exc():
     typ, value, tb = sys.exc_info()

--- a/cfut/remote.py
+++ b/cfut/remote.py
@@ -1,5 +1,5 @@
 """Tools for executing remote commands."""
-from cloud import serialization
+import cloudpickle
 import sys
 import os
 import traceback
@@ -14,21 +14,23 @@ def format_remote_exc():
 
 def worker(workerid):
     """Called to execute a job on a remote host."""
+    print("worker")
     try:
-        with open(INFILE_FMT % workerid) as f:
+        with open(INFILE_FMT % workerid, 'rb') as f:
             indata = f.read()
-        fun, args, kwargs = serialization.deserialize(indata)
-
+        fun, args, kwargs = cloudpickle.loads(indata)
         result = True, fun(*args, **kwargs)
-        out = serialization.serialize(result, True)
+        out = cloudpickle.dumps(result, True)
 
-    except:
+    except Exception as e:
+        print(traceback.format_exc())
+
         result = False, format_remote_exc()
-        out = serialization.serialize(result, False)
+        out = cloudpickle.dumps(result, False)
 
     destfile = OUTFILE_FMT % workerid
     tempfile = destfile + '.tmp'
-    with open(tempfile, 'w') as f:
+    with open(tempfile, 'wb') as f:
         f.write(out)
     os.rename(tempfile, destfile)
 

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -4,16 +4,16 @@ import re
 import os
 import threading
 import time
-from .util import chcall, random_string
+from .util import chcall, random_string, local_filename
 
-LOG_FILE = "slurmpy.log"
-OUTFILE_FMT = "slurmpy.stdout.{}.log"
+LOG_FILE = local_filename("slurmpy.log")
+OUTFILE_FMT = local_filename("slurmpy.stdout.{}.log")
 
 def submit_text(job):
     """Submits a Slurm job represented as a job file string. Returns
     the job ID.
     """
-    filename = '_temp_{}.sh'.format(random_string())
+    filename = local_filename('_temp_{}.sh'.format(random_string()))
     with open(filename, 'w') as f:
         f.write(job)
     jobid, _ = chcall('sbatch --parsable {}'.format(filename))

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -16,8 +16,7 @@ def submit_text(job):
     filename = '_temp_{}.sh'.format(random_string())
     with open(filename, 'w') as f:
         f.write(job)
-    out, _ = chcall('sbatch {}'.format(filename))
-    jobid = re.search(r'job (\d+)', out).group(1)
+    jobid, _ = chcall('sbatch --parsable {}'.format(filename))
     os.unlink(filename)
     return int(jobid)
 

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -20,12 +20,13 @@ def submit_text(job):
     os.unlink(filename)
     return int(jobid)
 
-def submit(cmdline, outpat=OUTFILE_FMT.format('%j')):
+def submit(cmdline, outpat=OUTFILE_FMT.format('%j'), additional_setup_lines=[]):
     """Starts a Slurm job that runs the specified shell command line.
     """
     script_lines = [
         "#!/bin/sh",
         "#SBATCH --output={}".format(outpat),
+        *additional_setup_lines,
         "srun {}".format(cmdline),
     ]
     return submit_text('\n'.join(script_lines))

--- a/cfut/util.py
+++ b/cfut/util.py
@@ -1,6 +1,10 @@
 import subprocess
 import random
 import string
+import os
+
+def local_filename(filename):
+    return os.path.join(os.getenv("CFUT_DIR", ".cfut"), filename)
 
 def random_string(length=32, chars=(string.ascii_letters + string.digits)):
     return ''.join(random.choice(chars) for i in range(length))

--- a/cfut/util.py
+++ b/cfut/util.py
@@ -3,7 +3,7 @@ import random
 import string
 import os
 
-def local_filename(filename):
+def local_filename(filename=""):
     return os.path.join(os.getenv("CFUT_DIR", ".cfut"), filename)
 
 def random_string(length=32, chars=(string.ascii_letters + string.digits)):

--- a/condor_example.py
+++ b/condor_example.py
@@ -14,7 +14,7 @@ def example_1():
     with cfut.CondorExecutor(True) as executor:
         futures = [executor.submit(square, n) for n in range(5)]
         for future in concurrent.futures.as_completed(futures):
-            print future.result()
+            print(future.result())
 
 def example_2():
     """Get host identifying information about the servers running
@@ -23,13 +23,13 @@ def example_2():
     with cfut.CondorExecutor(False) as executor:
         futures = [executor.submit(hostinfo) for n in range(5)]
         for future in concurrent.futures.as_completed(futures):
-            print future.result().strip()
+            print(future.result().strip())
 
 def example_3():
     """Demonstrates the use of the map() convenience function.
     """
     exc = cfut.CondorExecutor(False)
-    print list(cfut.map(exc, square, [5, 7, 11]))
+    print(list(cfut.map(exc, square, [5, 7, 11])))
 
 if __name__ == '__main__':
     example_1()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='clusterfutures',
 
       packages=['cfut'],
       install_requires=[
-          'cloud',
+          'cloudpickle',
           'futures',
       ],
 

--- a/slurm_example.py
+++ b/slurm_example.py
@@ -1,6 +1,6 @@
 import cfut
-import concurrent.futures
 import subprocess
+import concurrent.futures
 
 # "Worker" functions.
 def square(n):
@@ -14,7 +14,7 @@ def example_1():
     with cfut.SlurmExecutor(True) as executor:
         futures = [executor.submit(square, n) for n in range(5)]
         for future in concurrent.futures.as_completed(futures):
-            print future.result()
+            print(future.result())
 
 def example_2():
     """Get host identifying information about the servers running
@@ -22,15 +22,14 @@ def example_2():
     """
     with cfut.SlurmExecutor(False) as executor:
         futures = [executor.submit(hostinfo) for n in range(15)]
-        print 'Some cluster nodes:'
         for future in concurrent.futures.as_completed(futures):
-            print future.result().strip()
+            print(future.result().strip())
 
 def example_3():
     """Demonstrates the use of the map() convenience function.
     """
     exc = cfut.SlurmExecutor(False)
-    print list(cfut.map(exc, square, [5, 7, 11]))
+    print(list(cfut.map(exc, square, [5, 7, 11])))
 
 if __name__ == '__main__':
     example_1()

--- a/slurm_example.py
+++ b/slurm_example.py
@@ -11,8 +11,9 @@ def hostinfo():
 def example_1():
     """Square some numbers on remote hosts!
     """
-    with cfut.SlurmExecutor(True) as executor:
-        futures = [executor.submit(square, n) for n in range(5)]
+    with cfut.SlurmExecutor(True, keep_logs=True) as executor:
+        job_count = 5
+        futures = [executor.submit(square, n) for n in range(job_count)]
         for future in concurrent.futures.as_completed(futures):
             print(future.result())
 


### PR DESCRIPTION
Write all temporary and log files into a configurable directory instead of the current working directory. By default the folder `.cfut` is used, but configurable by `CFUT_DIR` env variable.