### PR TITLE
Add submit_array and map_array functions to evaluate inputs in job arrays and in batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cfut/__pycache__
+clusterfutures.egg-info

--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -232,8 +232,8 @@ def map(executor, func, args, ordered=True):
             yield fut.result()
 
 def map_array(executor, func, args, ordered=True,additional_setup_lines=[]):
-    """Convenience function to map a function over cluster jobs. Given
-    a function and an iterable, generates results. (Works like
+    """Convenience function to map a function over cluster job arrays (--array).
+    Given a function and an iterable, generates results. (Works like
     ``itertools.imap``.) If ``ordered`` is False, then the values are
     generated in an undefined order, possibly more quickly.
     """

--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -164,29 +164,44 @@ class SlurmExecutor(ClusterExecutor):
         except OSError:
             pass
 
-    def submit_array(self, fun, args, additional_setup_lines=[],kwargs=[]):
-        """Submit a job to the pool. args should be single iterable, don't accept kwargs for now"""
+    def submit_array(self, fun, args, additional_setup_lines=[],kwargs=[],batch_size=1):
+        """Submit a job to the pool. args should be single iterable,
+        kwargs still needs to be tested, input as list of mappings for now"""
         if len(kwargs) == 0:
             kwargs = [{} for _ in args] # empty dicts
         elif len(kwargs) != len(args):
             raise NotImplementedError('Number of kwarg dicts must equal number of arg lists')
-        # Start the job.
+        # Start the job array.
         workerids = []
         workerid_base = random_string()
-        for i, (arg,kwarg) in enumerate(zip(args,kwargs)):
+        if len(args) % batch_size != 0: # TODO: make compatible with number of args non-divisible by batch size (some workers do additional work)
+            raise NotImplementedError('Number of arguments must be divisible by batch size')
+
+        num_jobs = int(len(args)/batch_size)
+        for i in range(0,num_jobs):
             workerid = workerid_base + '_%d' % i # i will be $SLURM_ARRAY_TASK_ID (starting at 0)
-            funcser = cloudpickle.dumps((fun, [arg], kwarg))
+            inds = (batch_size*i,batch_size*(i+1))
+            arg = args[inds[0]:inds[1]] # list of args in each batch
+            kwarg = kwargs[inds[0]:inds[1]] # list of kwargs in each batch
+            funcser = cloudpickle.dumps((fun,arg,kwarg))
             with open(INFILE_FMT % workerid, 'wb') as f:
                 f.write(funcser)
             workerids.append(workerid)
 
+        # for i, (arg,kwarg) in enumerate(zip(args,kwargs)):
+        #     workerid = workerid_base + '_%d' % i # i will be $SLURM_ARRAY_TASK_ID (starting at 0)
+        #     funcser = cloudpickle.dumps((fun, [arg], kwarg))
+        #     with open(INFILE_FMT % workerid, 'wb') as f:
+        #         f.write(funcser)
+        #     workerids.append(workerid)
+
         # submit job array with length equal to number of arguments,
         # each job in array matches a workerid pickle file (fully parallelized)
-        additional_setup_lines.append("#SBATCH --array=0-{}".format(len(args)-1))
+        additional_setup_lines.append("#SBATCH --array=0-{}".format(num_jobs-1))
         jobid = self._start_array(workerid_base, additional_setup_lines)
-        jobids = ['%d_%d' % (jobid,i) for i in range(0,len(args))] # note: using string, rather than int
+        jobids = ['%d_%d' % (jobid,i) for i in range(0,num_jobs)] # note: using string, rather than int
         if self.debug:
-            print("job array submitted: %d_0-%d" % (jobid,len(args)-1), file=sys.stdout)
+            print("job array submitted: %d_0-%d" % (jobid,num_jobs-1), file=sys.stderr)
 
         # Thread will wait for all jobs to finish.
         futs = []
@@ -218,7 +233,7 @@ class CondorExecutor(ClusterExecutor):
         if os.path.exists(self.logfile):
             os.unlink(self.logfile)
 
-def map(executor, func, args, ordered=True):
+def map(executor, func, args, ordered=True,additional_setup_lines=[]):
     """Convenience function to map a function over cluster jobs. Given
     a function and an iterable, generates results. (Works like
     ``itertools.imap``.) If ``ordered`` is False, then the values are
@@ -227,17 +242,27 @@ def map(executor, func, args, ordered=True):
     with executor:
         futs = []
         for arg in args:
-            futs.append(executor.submit(func, arg))
+            futs.append(executor.submit(func, arg, additional_setup_lines=additional_setup_lines))
         for fut in (futs if ordered else futures.as_completed(futs)):
             yield fut.result()
 
-def map_array(executor, func, args, ordered=True,additional_setup_lines=[]):
+def map_array(executor, func, args, ordered=True,additional_setup_lines=[],batch_size=1):
     """Convenience function to map a function over cluster job arrays (--array).
     Given a function and an iterable, generates results. (Works like
     ``itertools.imap``.) If ``ordered`` is False, then the values are
     generated in an undefined order, possibly more quickly.
     """
+    results = [] # if batch_size > 1
     with executor:
-        futs = executor.submit_array(func, args, additional_setup_lines)
+        futs = executor.submit_array(func, args, additional_setup_lines,batch_size=batch_size)
         for fut in (futs if ordered else futures.as_completed(futs)):
-            yield fut.result()
+            if batch_size == 1:
+                yield fut.result()
+            else:
+                # yield zip(*fut.result())
+                results.append(list(fut.result()))
+
+        if batch_size > 1:
+            from itertools import chain
+            # yield from zip(*results)
+            yield from chain(*results)

--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -96,7 +96,7 @@ class ClusterExecutor(futures.Executor):
             if not self.jobs:
                 self.jobs_empty_cond.notify_all()
         if self.debug:
-            print("job completed: %s" % str(jobid), file=sys.stderr)
+            print("job completed: %s" % str(jobid), file=sys.stdout)
 
         with open(OUTFILE_FMT % workerid, 'rb') as f:
             outdata = f.read()
@@ -125,7 +125,7 @@ class ClusterExecutor(futures.Executor):
         jobid = self._start(workerid, additional_setup_lines)
 
         if self.debug:
-            print("job submitted: %s" % str(jobid), file=sys.stderr)
+            print("job submitted: %s" % str(jobid), file=sys.stdout)
 
         # Thread will wait for it to finish.
         self.wait_thread.wait(OUTFILE_FMT % workerid, jobid)

--- a/cfut/remote.py
+++ b/cfut/remote.py
@@ -20,7 +20,14 @@ def worker(workerid):
         with open(INFILE_FMT % workerid, 'rb') as f:
             indata = f.read()
         fun, args, kwargs = cloudpickle.loads(indata)
-        result = True, fun(*args, **kwargs)
+        if isinstance(args,list) and len(args) > 1:
+            result = True, [fun(*(arg,), **kwarg) for arg,kwarg in zip(args,kwargs)]
+        else:
+            if isinstance(kwargs,list):
+                kwargs = kwargs[0]
+
+            result = True, fun(*args, **kwargs)
+
         out = cloudpickle.dumps(result)
 
     except Exception as e:

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -30,3 +30,14 @@ def submit(cmdline, outpat=OUTFILE_FMT.format('%j'), additional_setup_lines=[]):
         "srun {}".format(cmdline),
     ]
     return submit_text('\n'.join(script_lines))
+
+def submit_array(cmdline, outpat=OUTFILE_FMT.format('%j'), additional_setup_lines=[]):
+    """Starts a Slurm job that runs the specified shell command line.
+    """
+    script_lines = [
+        "#!/bin/sh",
+        "#SBATCH --output={}".format(outpat),
+        *additional_setup_lines,
+        "{}".format(cmdline),
+    ]
+    return submit_text('\n'.join(script_lines))

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -33,6 +33,8 @@ def submit(cmdline, outpat=OUTFILE_FMT.format('%j'), additional_setup_lines=[]):
 
 def submit_array(cmdline, outpat=OUTFILE_FMT.format('%j'), additional_setup_lines=[]):
     """Starts a Slurm job that runs the specified shell command line.
+    Compatible with job array (passed in additional_setup_lines), executes shell command line
+    within slurm job, rather than as job step using srun
     """
     script_lines = [
         "#!/bin/sh",

--- a/slurm_example.py
+++ b/slurm_example.py
@@ -32,7 +32,7 @@ def example_3():
     """Demonstrates the use of the map() convenience function.
     """
     exc = cfut.SlurmExecutor(True)
-    additional_setup_lines = ["#SBATCH -p wmglab"] # only works if srun -p wmglab also included
+    additional_setup_lines = []
     print(list(cfut.map(exc, square, [5, 7, 11],ordered=True,additional_setup_lines=additional_setup_lines)))
 
 def example_4():

--- a/slurm_example.py
+++ b/slurm_example.py
@@ -38,19 +38,19 @@ def example_4():
     """Demonstrates the use of the map_array() convenience function.
     """
     exc = cfut.SlurmExecutor(True)
-    additional_setup_lines = ["#SBATCH -p wmglab"]
+    additional_setup_lines = []
     print(list(cfut.map_array(exc, square, [5, 7, 11],additional_setup_lines)))
 
-def example_5():
-    """Demonstrates the use of the map_array() convenience function.
+def example_5(): # TODO: implement variable *args and **kwargs, currently doesn't work
+    """Demonstrates the use of the map_array() convenience function with two arguments.
     """
     exc = cfut.SlurmExecutor(True)
-    additional_setup_lines = ["#SBATCH -p wmglab"]
+    additional_setup_lines = []
     print(list(cfut.map_array(exc, square_sum, [1, 2, 3],[2,3,4],additional_setup_lines)))
 
 if __name__ == '__main__':
-    # example_1()
-    # example_2()
-    # example_3()
-    # example_4()
-    example_5()
+    example_1()
+    example_2()
+    example_3()
+    example_4()
+    # example_5()

--- a/slurm_example.py
+++ b/slurm_example.py
@@ -5,6 +5,8 @@ import concurrent.futures
 # "Worker" functions.
 def square(n):
     return n * n
+def square_sum(n,m):
+    return n * n + m * m
 def hostinfo():
     return subprocess.check_output('uname -a', shell=True)
 
@@ -29,10 +31,26 @@ def example_2():
 def example_3():
     """Demonstrates the use of the map() convenience function.
     """
-    exc = cfut.SlurmExecutor(False)
+    exc = cfut.SlurmExecutor(True)
     print(list(cfut.map(exc, square, [5, 7, 11])))
 
+def example_4():
+    """Demonstrates the use of the map_array() convenience function.
+    """
+    exc = cfut.SlurmExecutor(True)
+    additional_setup_lines = ["#SBATCH -p wmglab"]
+    print(list(cfut.map_array(exc, square, [5, 7, 11],additional_setup_lines)))
+
+def example_5():
+    """Demonstrates the use of the map_array() convenience function.
+    """
+    exc = cfut.SlurmExecutor(True)
+    additional_setup_lines = ["#SBATCH -p wmglab"]
+    print(list(cfut.map_array(exc, square_sum, [1, 2, 3],[2,3,4],additional_setup_lines)))
+
 if __name__ == '__main__':
-    example_1()
-    example_2()
-    example_3()
+    # example_1()
+    # example_2()
+    # example_3()
+    # example_4()
+    example_5()

--- a/slurm_example.py
+++ b/slurm_example.py
@@ -32,14 +32,18 @@ def example_3():
     """Demonstrates the use of the map() convenience function.
     """
     exc = cfut.SlurmExecutor(True)
-    print(list(cfut.map(exc, square, [5, 7, 11])))
+    additional_setup_lines = ["#SBATCH -p wmglab"] # only works if srun -p wmglab also included
+    print(list(cfut.map(exc, square, [5, 7, 11],ordered=True,additional_setup_lines=additional_setup_lines)))
 
 def example_4():
     """Demonstrates the use of the map_array() convenience function.
     """
     exc = cfut.SlurmExecutor(True)
     additional_setup_lines = []
-    print(list(cfut.map_array(exc, square, [5, 7, 11],additional_setup_lines)))
+    batch_size = 1
+    print(list(cfut.map_array(exc, square,  [5, 7, 11],ordered=True,
+                              additional_setup_lines=additional_setup_lines,
+                              batch_size=batch_size)))
 
 def example_5(): # TODO: implement variable *args and **kwargs, currently doesn't work
     """Demonstrates the use of the map_array() convenience function with two arguments.


### PR DESCRIPTION
Original Slurm Executor only allows submitting each set of arguments as individual Slurm jobs, effectively mapping each single function evaluation to a single job. These changes add a submit_array method to SlurmExecutor that's called by map_array convenience function, as well as a _start_array and slurm.submit_array functions, which submit a single job array for all arguments input to executor. Also includes batch_size parameter to enable batching parameter sets together onto each job, currently number of arguments must be divisible by batch_size, otherwise throws error. 

Shouldn't affect default behavior with submit() and map(). 

Currently only tested for single position argument input as list of single objects or list of single lists. Should work for kwargs input as list of mappings (e.g. dicts), but hasn't been tested.  

slurm_example.py shows example using map_array. Also allows inputting additional_setup_lines to map() function