### PR TITLE
Remove dependency on futures, add Python version specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setup(name='clusterfutures',
       packages=['cfut'],
       install_requires=[
           'cloudpickle',
-          'futures',
       ],
+      python_requires='>=3.5',
 
       classifiers=[
           'Intended Audience :: Developers',


### PR DESCRIPTION
I noticed that this package has a dependency on [futures](https://pypi.org/project/futures/), which it doesn't seem to use. `futures` is the Python 2 backport of `concurrent.futures`, while clusterfutures is Python 3 only (#2).

While I'm looking at it, I also added a line to specify which versions of Python it's compatible with. 3.5+ is an educated guess from looking at the code; I can change that if you want.

Thanks for clusterfutures; we're appreciating the simplicity of just doing a `map()` call to quickly have stuff running on our Slurm cluster. If you'd like I could add a few simple tests for it and set up CI.