### PR TITLE
Allow passing additional_setup_lines when creating SlurmExecutor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 /build/
 /dist/
+*.egg-info/


### PR DESCRIPTION
I think this is the neatest way to enable using additional_setup_lines with map() (both `cfut.map()` and the `executor.map()` method).

This also fits with the `concurrent.futures` module. Both `ThreadPoolExecutor` and `ProcessPoolExecutor` take implementation-specific options (`thread_name_prefix`, `mp_context`) as constructor parameters.

One limitation is that, if you want to submit different jobs with different options - e.g. a different time limit for step 1 & step 2 - you would have to create two executors to do that. Adding it as a parameter for `map()` would be more convenient for that scenario. However, creating an executor is fairly cheap, so I don't think this is a big problem.