### PR TITLE
Get rid of RuntimeWarning in Slurm logs from launching cfut.remote

### DIFF
--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -6,8 +6,9 @@ import threading
 import time
 from . import condor
 from . import slurm
-from .remote import INFILE_FMT, OUTFILE_FMT
-from .util import random_string, local_filename
+from .util import (
+    random_string, local_filename, INFILE_FMT, OUTFILE_FMT,
+)
 import cloudpickle
 
 __version__ = '0.4'

--- a/cfut/remote.py
+++ b/cfut/remote.py
@@ -3,10 +3,7 @@ import cloudpickle
 import sys
 import os
 import traceback
-from .util import local_filename
-
-INFILE_FMT = local_filename('cfut.in.%s.pickle')
-OUTFILE_FMT = local_filename('cfut.out.%s.pickle')
+from .util import INFILE_FMT, OUTFILE_FMT
 
 def format_remote_exc():
     typ, value, tb = sys.exc_info()

--- a/cfut/util.py
+++ b/cfut/util.py
@@ -6,6 +6,9 @@ import os
 def local_filename(filename=""):
     return os.path.join(os.getenv("CFUT_DIR", ".cfut"), filename)
 
+INFILE_FMT = local_filename('cfut.in.%s.pickle')
+OUTFILE_FMT = local_filename('cfut.out.%s.pickle')
+
 def random_string(length=32, chars=(string.ascii_letters + string.digits)):
     return ''.join(random.choice(chars) for i in range(length))
 


### PR DESCRIPTION
Looking at the logs from Slurm jobs run by clusterfutures, I see this warning:

```
/gpfs/exfel/sw/software/xfel_anaconda3/1.1.2/lib/python3.7/runpy.py:125: RuntimeWarning: 'cfut.remote' found in sys.modules after import of package 'cfut', but prior to execution of 'cfut.remote'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
```

This is because importing `cfut` also imports `cfut.remote`. It doesn't appear to cause any problems, but it's easy to rearrange things a bit to avoid it.