### PR TITLE
Add option to specify additional import paths for worker

### DIFF
--- a/cfut/remote.py
+++ b/cfut/remote.py
@@ -10,9 +10,16 @@ def format_remote_exc():
     tb = tb.tb_next  # Remove root call to worker().
     return ''.join(traceback.format_exception(typ, value, tb))
 
-def worker(workerid):
+def worker(workerid, extra_import_paths="!"):
     """Called to execute a job on a remote host."""
     print("worker")
+    if extra_import_paths != '!':
+        extra_import_paths = extra_import_paths.split(':')
+        print("Prepending %d paths to sys.path:" % len(extra_import_paths))
+        for p in extra_import_paths:
+            print(" ", p)
+        sys.path[:0] = extra_import_paths
+
     try:
         with open(INFILE_FMT % workerid, 'rb') as f:
             indata = f.read()

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -1,6 +1,7 @@
 """Abstracts access to a Slurm cluster via its command-line tools.
 """
 import os
+import shlex
 from .util import chcall, random_string, local_filename
 
 LOG_FILE = local_filename("slurmpy.log")
@@ -24,6 +25,6 @@ def submit(cmdline, outpat=OUTFILE_FMT.format('%j'), additional_setup_lines=[]):
         "#!/bin/sh",
         "#SBATCH --output={}".format(outpat),
         *additional_setup_lines,
-        "srun {}".format(cmdline),
+        shlex.join(['srun', *cmdline]),
     ]
     return submit_text('\n'.join(script_lines))

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -1,8 +1,7 @@
 """Abstracts access to a Slurm cluster via its command-line tools.
 """
 import os
-import shlex
-from .util import chcall, random_string, local_filename
+from .util import chcall, random_string, local_filename, shlex_join
 
 LOG_FILE = local_filename("slurmpy.log")
 OUTFILE_FMT = local_filename("slurmpy.stdout.{}.log")
@@ -25,6 +24,6 @@ def submit(cmdline, outpat=OUTFILE_FMT.format('%j'), additional_setup_lines=[]):
         "#!/bin/sh",
         "#SBATCH --output={}".format(outpat),
         *additional_setup_lines,
-        shlex.join(['srun', *cmdline]),
+        shlex_join(['srun', *cmdline]),
     ]
     return submit_text('\n'.join(script_lines))

--- a/cfut/util.py
+++ b/cfut/util.py
@@ -1,7 +1,8 @@
-import subprocess
-import random
-import string
 import os
+import random
+import shlex
+import string
+import subprocess
 
 def local_filename(filename=""):
     return os.path.join(os.getenv("CFUT_DIR", ".cfut"), filename)
@@ -41,3 +42,9 @@ def chcall(command, stdin=None):
     if code != 0:
         raise CommandError(command, code, stderr)
     return stdout, stderr
+
+
+# This is part of the shlex module from Python 3.8. This is copied from 3.10:
+def shlex_join(split_command):
+    """Return a shell-escaped string from *split_command*."""
+    return ' '.join(shlex.quote(arg) for arg in split_command)


### PR DESCRIPTION
Closes #14.

This is a fairly explicit option, where you specify paths to add to `sys.path` explicitly. If the user wants to copy the whole of `sys.path`, they could just pass `additional_import_paths=sys.path` - the worker's sys.path would end up with some duplicate entries, but I don't think that actually matters.

It would be easy to have this a bit more automatic, so you pass something like `copy_import_paths=True` to override the whole of `sys.path` in the worker.