### PR TITLE
Set FileWaitThread daemon property

### DIFF
--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -31,7 +31,7 @@ class FileWaitThread(threading.Thread):
         associated with the filename of each file that is created.
         ``interval`` specifies the polling rate.
         """
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, daemon=True)
         self.callback = callback
         self.interval = interval
         self.waiting = {}


### PR DESCRIPTION
This means that the process won't stay alive just to keep running a FileWaitThread. I.e. if you create an executor and then try to exit Python without calling `executor.shutdown()`, it will exit rather than hanging.

It's generally a good idea to clean up threads explicitly rather than relying on this, but it's nice for libraries to behave reasonably even if people don't do this. :slightly_smiling_face: 