### PR TITLE
Poll slurm to catch jobs that exited without writing output file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout

--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -45,8 +45,7 @@ class FileWaitThread(threading.Thread):
 
     def stop(self):
         """Stop the thread soon."""
-        with self.lock:
-            self.shutdown = True
+        self.shutdown = True
 
     def wait(self, filename, value):
         """Adds a new filename (and its associated callback value) to
@@ -57,14 +56,14 @@ class FileWaitThread(threading.Thread):
 
     def run(self):
         for i in count():
+            if self.shutdown:
+                return
+
             self.check(i)
             time.sleep(self.interval)
 
     def check(self, i):
         with self.lock:
-            if self.shutdown:
-                return
-
             # Poll for each file.
             for filename in list(self.waiting):
                 if os.path.exists(filename):

--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -66,6 +66,11 @@ class FileWaitThread(threading.Thread):
             time.sleep(self.interval)
 
     def check(self, i):
+        """Do one check for completed jobs
+
+        The i parameter allows subclasses like SlurmWaitThread to do something
+        on every Nth check.
+        """
         # Poll for each file.
         for filename in list(self.waiting):
             if os.path.exists(filename):

--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -5,6 +5,8 @@ import os
 import sys
 import threading
 import time
+import traceback
+
 from . import condor
 from . import slurm
 from .util import (
@@ -173,7 +175,13 @@ class SlurmWaitThread(FileWaitThread):
     def check(self, i):
         super().check(i)
         if i % (self.slurm_poll_interval // self.interval) == 0:
-            finished_jobs = slurm.jobs_finished(self.waiting.values())
+            try:
+                finished_jobs = slurm.jobs_finished(self.waiting.values())
+            except Exception:
+                # Don't abandon completion checking if jobs_finished errors
+                traceback.print_exc()
+                return
+
             if not finished_jobs:
                 return
 

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -1,6 +1,7 @@
 """Abstracts access to a Slurm cluster via its command-line tools.
 """
 import os
+from subprocess import run, PIPE
 from .util import chcall, random_string, local_filename, shlex_join
 
 LOG_FILE = local_filename("slurmpy.log")
@@ -27,3 +28,20 @@ def submit(cmdline, outpat=OUTFILE_FMT.format('%j'), additional_setup_lines=[]):
         shlex_join(['srun', *cmdline]),
     ]
     return submit_text('\n'.join(script_lines))
+
+STATES_FINISHED = {  # https://slurm.schedmd.com/squeue.html#lbAG
+    'BOOT_FAIL',  'CANCELLED', 'COMPLETED',  'DEADLINE', 'FAILED',
+    'NODE_FAIL', 'OUT_OF_MEMORY', 'PREEMPTED', 'SPECIAL_EXIT', 'TIMEOUT',
+}
+
+def jobs_finished(job_ids):
+    res = run([
+        'squeue', '--noheader', '--format=%i %T', '--jobs', ','.join(job_ids),
+        '--states=all',
+    ], stdout=PIPE, stderr=PIPE, encoding='utf-8', check=True)
+    id_to_state = dict([
+        l.strip().partition(' ')[::2] for l in res.stdout.splitlines()
+    ])
+    # Finished jobs only stay in squeue for a few mins (configurable). If
+    # a job ID isn't there, we'll assume it's finished.
+    return {j for j in job_ids if id_to_state.get(j, 'COMPLETED') in STATES_FINISHED}

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -36,8 +36,8 @@ STATES_FINISHED = {  # https://slurm.schedmd.com/squeue.html#lbAG
 
 def jobs_finished(job_ids):
     res = run([
-        'squeue', '--noheader', '--format=%i %T', '--jobs', ','.join(job_ids),
-        '--states=all',
+        'squeue', '--noheader', '--format=%i %T',
+        '--jobs', ','.join([str(j) for j in job_ids]), '--states=all',
     ], stdout=PIPE, stderr=PIPE, encoding='utf-8', check=True)
     id_to_state = dict([
         l.strip().partition(' ')[::2] for l in res.stdout.splitlines()

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -35,6 +35,8 @@ STATES_FINISHED = {  # https://slurm.schedmd.com/squeue.html#lbAG
 }
 
 def jobs_finished(job_ids):
+    """Check which ones of the given Slurm jobs already finished
+    """
 
     # If there is no Slurm job to check, return right away
     if not job_ids:

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -35,6 +35,11 @@ STATES_FINISHED = {  # https://slurm.schedmd.com/squeue.html#lbAG
 }
 
 def jobs_finished(job_ids):
+
+    # If there is no Slurm job to check, return right away
+    if not job_ids:
+        return set()
+
     res = run([
         'squeue', '--noheader', '--format=%i %T',
         '--jobs', ','.join([str(j) for j in job_ids]), '--states=all',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='clusterfutures',
       install_requires=[
           'cloudpickle',
       ],
-      python_requires='>=3.5',
+      python_requires='>=3.6',
       extras_require={
           'test': ['pytest', 'testpath>=0.5']
       },

--- a/slurm_example.py
+++ b/slurm_example.py
@@ -7,6 +7,11 @@ def square(n):
     return n * n
 def hostinfo():
     return subprocess.check_output('uname -a', shell=True)
+def just_raise():
+    raise RuntimeError("error")
+def just_exit():
+    import sys
+    sys.exit()
 
 def example_1():
     """Square some numbers on remote hosts!
@@ -32,7 +37,25 @@ def example_3():
     exc = cfut.SlurmExecutor(False)
     print(list(cfut.map(exc, square, [5, 7, 11])))
 
+def example_4():
+    """Demonstrate the behavior in case of an error
+    """
+    with cfut.SlurmExecutor(True, keep_logs=True) as executor:
+        future = executor.submit(just_raise)
+        res = future.result()
+
+def example_5():
+    """
+    Demonstrate the behavior in case of unexpected exit
+    """
+    with cfut.SlurmExecutor(True, keep_logs=True) as executor:
+        future = executor.submit(just_exit)
+        res = future.result()
+
+
 if __name__ == '__main__':
     example_1()
     example_2()
     example_3()
+    # example_4()  # warning: this raises an exception
+    # example_5()  # warning: this takes ~30 seconds

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -8,14 +8,15 @@ def square(n):
 
 
 def test_submit():
-    with cfut.SlurmExecutor(True, keep_logs=True) as executor:
-        with MockCommand.fixed_output('sbatch', stdout='000000') as sbatch:
-            fut = executor.submit(square, 2)
-        sbatch.assert_called()
+    with MockCommand.fixed_output('squeue', stdout='000000 RUNNING'):
+        with cfut.SlurmExecutor(True, keep_logs=True) as executor:
+            with MockCommand.fixed_output('sbatch', stdout='000000') as sbatch:
+                fut = executor.submit(square, 2)
+            sbatch.assert_called()
 
-        assert not fut.done()
-        run_all_outstanding_work()
-        assert fut.result(timeout=3) == 4
+            assert not fut.done()
+            run_all_outstanding_work()
+            assert fut.result(timeout=3) == 4
 
 SBATCH_JOB_COUNT = """
 from pathlib import Path
@@ -28,11 +29,19 @@ counter_file.write_text(str(count))
 print(count)
 """
 
-def test_map():
-    with cfut.SlurmExecutor(True, keep_logs=True) as executor:
-        with MockCommand('sbatch', python=SBATCH_JOB_COUNT) as sbatch:
-            result_iter = executor.map(square, range(4), timeout=5)
-        sbatch.assert_called()
+SQUEUE_STILL_GOING = """
+jobs_arg_ix = sys.argv.index('--jobs') + 1
+job_ids = sys.argv[jobs_arg_ix].split(',')
+for jid in job_ids:
+    print(jid, 'RUNNING')
+"""
 
-        run_all_outstanding_work()
-        assert list(result_iter) == [0, 1, 4, 9]
+def test_map():
+    with MockCommand('squeue', python=SQUEUE_STILL_GOING):
+        with cfut.SlurmExecutor(True, keep_logs=True) as executor:
+            with MockCommand('sbatch', python=SBATCH_JOB_COUNT) as sbatch:
+                result_iter = executor.map(square, range(4), timeout=5)
+            sbatch.assert_called()
+
+            run_all_outstanding_work()
+            assert list(result_iter) == [0, 1, 4, 9]


### PR DESCRIPTION
A partial solution for #18. As we discussed, polling Slurm is the crude but complete option: it should catch any kind of crash or cancellation, but we don't want to poll Slurm too often, so there's a significant lag before it picks up the failure. I've made the polling interval 30 seconds by default.

I've implemented this by extending the existing FileWaitThread to also poll Slurm on every 30th check. This has some limitations compared to running a separate thread - you can only poll Slurm just after the file checks, so checking the files every 10 seconds and Slurm jobs every 15 is not an option - but in general I think it's easier to follow code and avoid bugs if I don't use more threads than necessary. But I've ended up catching all exceptions from jobs_finished so they don't make it give up on checking files, which feels kind of kludgy. :confused: 

I've dropped Python 3.5 support in this PR. It's easy to add back if required, but even 3.6 is already EOL, and it's a bit of effort to remember not to use f-strings.

Tested by modifying the example:

```python
import cfut
import sys

def square(n):
    if n  == 7:
        sys.exit()
    return n * n

with cfut.SlurmExecutor(additional_setup_lines=['#SBATCH -p exfel']) as executor:
    for result in executor.map(square, [5, 7, 11]):
        print(result)
```

```
Traceback (most recent call last):
  File "/home/kluyvert/scratch/cfut-crash-worker.py", line 10, in <module>
    for result in executor.map(square, [5, 7, 11]):
  File "/gpfs/exfel/sw/software/xfel_anaconda3/1.1.2/lib/python3.7/concurrent/futures/_base.py", line 586, in result_iterator
    yield fs.pop().result()
  File "/gpfs/exfel/sw/software/xfel_anaconda3/1.1.2/lib/python3.7/concurrent/futures/_base.py", line 425, in result
    return self.__get_result()
  File "/gpfs/exfel/sw/software/xfel_anaconda3/1.1.2/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
cfut.JobDied: Cluster job 10484726 finished without writing a result
```