### PR TITLE
Handle errors in executor map

### DIFF
--- a/slurm_example.py
+++ b/slurm_example.py
@@ -52,6 +52,14 @@ def example_5():
         future = executor.submit(just_exit)
         res = future.result()
 
+def example_6():
+    """
+    Demonstrate the behavior in case of an error within a map
+    """
+    with cfut.SlurmExecutor(True, keep_logs=True) as executor:
+        results_generator = executor.map(just_raise, [0, 1, 2])
+        for result in results_generator:
+            print(result)
 
 if __name__ == '__main__':
     example_1()
@@ -59,3 +67,4 @@ if __name__ == '__main__':
     example_3()
     # example_4()  # warning: this raises an exception
     # example_5()  # warning: this takes ~30 seconds
+    # example_6()  # warning: this raises an exception

--- a/slurm_example.py
+++ b/slurm_example.py
@@ -12,6 +12,8 @@ def just_raise():
 def just_exit():
     import sys
     sys.exit()
+def just_raise_in_map(n):
+    raise RuntimeError("error for n=%i" % n)
 
 def example_1():
     """Square some numbers on remote hosts!
@@ -57,7 +59,7 @@ def example_6():
     Demonstrate the behavior in case of an error within a map
     """
     with cfut.SlurmExecutor(True, keep_logs=True) as executor:
-        results_generator = executor.map(just_raise, [0, 1, 2])
+        results_generator = executor.map(just_raise_in_map, [0, 1, 2])
         for result in results_generator:
             print(result)
 


### PR DESCRIPTION
Closes #22

When one of the futures in `ClusterExecutor.map()` (method inherited from the standard `Executor` class) raises an exception, all the other futures created by `map` are cancelled. However `ClusterExecutor._completion` may still try to set their results or exceptions (via `set_result` or `set_exception`), which will fail and raise a `concurrent.futures.InvalidStateError`.

With this PR, we catch all `InvalidStateError` appearing in `set_result` or `set_exception` (in the `_completion` method), and simply exit from `_completion` when they are raised. The rationale here (which comes from concurrent.futures) is that if even just one of the parallel tasks failed, then all the others are automatically invalid.

---

I also included a new `example_6()` in `slurm_example.py`. When running only that example, the output looks like
```
job submitted: 31
job submitted: 32
job submitted: 33
job completed: 31
job completed: 32
The future of job 32 was cancelled, skip it
job completed: 33
The future of job 33 was cancelled, skip it
Traceback (most recent call last):
  File "slurm_example.py", line 70, in <module>
    example_6()  # warning: this raises an exception
  File "slurm_example.py", line 61, in example_6
    for result in results_generator:
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 619, in result_iterator
    yield fs.pop().result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 444, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
cfut.RemoteException: 
TypeError: just_raise() takes 0 positional arguments but 1 was given
```

---

I am happy to make changes if they are needed (including rephrasing the error message, or removing the additional method `_print_cancelled_future_message` if it looks too much).

---

Side comment: this PR doesn't change [the custom `map` function of clusterfutures](https://github.com/sampsyo/clusterfutures/blob/master/cfut/__init__.py#L257), since in that case futures are never cancelled.